### PR TITLE
Add support for annotation based validation

### DIFF
--- a/components/org.wso2.carbon.identity.api.dispatcher/pom.xml
+++ b/components/org.wso2.carbon.identity.api.dispatcher/pom.xml
@@ -148,6 +148,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.user.api</groupId>
             <artifactId>org.wso2.carbon.identity.api.user.challenge.common</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.api.dispatcher/src/main/java/org/wso2/carbon/identity/api/dispatcher/InputValidationExceptionMapper.java
+++ b/components/org.wso2.carbon.identity.api.dispatcher/src/main/java/org/wso2/carbon/identity/api/dispatcher/InputValidationExceptionMapper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.api.dispatcher;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.common.error.ErrorDTO;
+import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Map input validation exceptions.
+ */
+public class InputValidationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
+
+    private static final Log log = LogFactory.getLog(InputValidationExceptionMapper.class);
+
+    private static final String ERROR_CODE = "UE-10000";
+    private static final String ERROR_MESSAGE = "Invalid Request";
+    private static final String ERROR_DESCRIPTION = "Provided request body content is not in the expected format.";
+
+    @Override
+    public Response toResponse(ConstraintViolationException e) {
+
+        StringBuilder description = new StringBuilder();
+        Set<ConstraintViolation<?>> constraintViolations = e.getConstraintViolations();
+
+        for (ConstraintViolation constraintViolation : constraintViolations) {
+            if (StringUtils.isNotBlank(description)) {
+                description.append(" ");
+            }
+            description.append(constraintViolation.getMessage());
+        }
+
+        if (StringUtils.isBlank(description)) {
+            description = new StringBuilder(ERROR_DESCRIPTION);
+        }
+
+        ErrorDTO errorDTO = new ErrorResponse.Builder()
+                .withCode(ERROR_CODE)
+                .withMessage(ERROR_MESSAGE)
+                .withDescription(description.toString())
+                .build(log, e.getMessage());
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(errorDTO)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.dispatcher/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.identity.api.dispatcher/src/main/webapp/WEB-INF/beans.xml
@@ -30,6 +30,11 @@
     <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer"/>
     <bean class="org.springframework.beans.factory.config.PreferencesPlaceholderConfigurer"/>
     <bean id="postprocess" class="org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor" />
+    <bean id="validationProvider" class="org.apache.cxf.validation.BeanValidationProvider" />
+    <bean id="validationInInterceptor"
+          class="org.apache.cxf.jaxrs.validation.JAXRSBeanValidationInInterceptor">
+        <property name="provider" ref="validationProvider"/>
+    </bean>
     <jaxrs:server id="server" address="/server/v1">
         <jaxrs:serviceBeans>
             <bean class="org.wso2.carbon.identity.rest.api.server.challenge.v1.ChallengesApi"/>
@@ -39,8 +44,12 @@
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
             <bean class="org.wso2.carbon.identity.api.dispatcher.JsonProcessingExceptionMapper"/>
             <bean class="org.wso2.carbon.identity.api.dispatcher.APIErrorExceptionMapper"/>
+            <bean class="org.wso2.carbon.identity.api.dispatcher.InputValidationExceptionMapper"/>
             <bean class="org.wso2.carbon.identity.api.dispatcher.DefaultExceptionMapper"/>
         </jaxrs:providers>
+        <jaxrs:inInterceptors>
+            <ref bean="validationInInterceptor"/>
+        </jaxrs:inInterceptors>
     </jaxrs:server>
     <jaxrs:server id="users" address="/users/v1">
         <jaxrs:serviceBeans>
@@ -60,7 +69,11 @@
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
             <bean class="org.wso2.carbon.identity.api.dispatcher.JsonProcessingExceptionMapper"/>
             <bean class="org.wso2.carbon.identity.api.dispatcher.APIErrorExceptionMapper"/>
+            <bean class="org.wso2.carbon.identity.api.dispatcher.InputValidationExceptionMapper"/>
             <bean class="org.wso2.carbon.identity.api.dispatcher.DefaultExceptionMapper"/>
         </jaxrs:providers>
+        <jaxrs:inInterceptors>
+            <ref bean="validationInInterceptor"/>
+        </jaxrs:inInterceptors>
     </jaxrs:server>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,11 @@
                 <artifactId>org.wso2.carbon.identity.rest.api.user.fido2.v1</artifactId>
                 <version>${identity.user.api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>6.0.17.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Purpose
> Add support for annotation-based validation.

Adding the @Valid tag will engage the validation for DTOs and methods.
ref: http://cxf.apache.org/docs/validationfeature.html#ValidationFeature-CommonBeanValidation1.1Interceptors
ref: dev mail "[IAM] Input validation for REST APIs"