### PR TITLE
Enable Keystore Service REST API

### DIFF
--- a/components/org.wso2.carbon.identity.api.dispatcher/pom.xml
+++ b/components/org.wso2.carbon.identity.api.dispatcher/pom.xml
@@ -259,6 +259,14 @@
 <!--            <groupId>org.wso2.carbon.identity.server.api</groupId>-->
 <!--            <artifactId>org.wso2.carbon.identity.api.server.application.management.v1</artifactId>-->
 <!--        </dependency>-->
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.keystore.v1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.keystore.common</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/components/org.wso2.carbon.identity.api.dispatcher/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.identity.api.dispatcher/src/main/webapp/WEB-INF/beans.xml
@@ -31,6 +31,7 @@
     <import resource="classpath:META-INF/cxf/challenge-server-v1-cxf.xml"/>
     <import resource="classpath:META-INF/cxf/email-template-server-v1-cxf.xml"/>
     <!--<import resource="classpath:META-INF/cxf/applications-server-v1-cxf.xml"/>-->
+    <import resource="classpath:META-INF/cxf/keystore-server-v1-cxf.xml"/>
 
     <import resource="classpath:META-INF/cxf/identity-governance-server-v1-cxf.xml"/>
     <context:property-placeholder/>
@@ -50,6 +51,7 @@
             <bean class="org.wso2.carbon.identity.rest.api.server.email.template.v1.EmailApi"/>
             <bean class="org.wso2.carbon.identity.api.server.identity.governance.v1.IdentityGovernanceApi"/>
 <!--            <bean class="org.wso2.carbon.identity.api.server.application.management.v1.ApplicationsApi"/>-->
+            <bean class="org.wso2.carbon.identity.api.server.keystore.v1.KeystoresApi"/>
         </jaxrs:serviceBeans>
         <jaxrs:providers>
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,16 @@
 <!--                <artifactId>org.wso2.carbon.identity.api.server.application.management.v1</artifactId>-->
 <!--                <version>${identity.server.api.version}</version>-->
 <!--            </dependency>-->
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.keystore.v1</artifactId>
+                <version>${identity.server.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.keystore.common</artifactId>
+                <version>${identity.server.api.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Relates to https://github.com/wso2/product-is/issues/6852

This is to enable the Keystore REST API implementation at [1] 

[1] https://github.com/wso2/identity-api-server/pull/58