### PR TITLE
Removing unwanted dependency on jboss-logging.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,12 @@
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>6.0.17.Final</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>


### PR DESCRIPTION
## Purpose
Remove unwanted dependency on jboss-logging jar used by the 'api' webapp.

## Goals
Remove unwanted dependency.
## Approach
