### PR TITLE
Update the build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |  Branch | Build Status | Travis CI Status |
 | :------------ |:------------- |:-------------
-| master      | [![Build Status](https://wso2.org/jenkins/job/platform-builds/job/identity-rest-dispatcher/badge/icon)](https://wso2.org/jenkins/job/platform-builds/job/identity-rest-dispatcher/) | [![Travis CI Status](https://travis-ci.org/wso2/identity-rest-dispatcher.svg?branch=master)](https://travis-ci.org/wso2/identity-rest-dispatcher?branch=master)|
+| master      | [![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fwso2.org%2Fjenkins%2Fjob%2Fplatform-builds%2Fjob%2Fidentity-rest-dispatcher%2F)](https://wso2.org/jenkins/job/platform-builds/job/identity-rest-dispatcher/) | [![Travis CI Status](https://travis-ci.org/wso2/identity-rest-dispatcher.svg?branch=master)](https://travis-ci.org/wso2/identity-rest-dispatcher?branch=master)|
 
 Aggregates the API implementations from [identity-api-user](https://github.com/wso2/identity-api-user/) and 
 [identity-api-server](https://github.com/wso2/identity-api-server/) builds a single webapp inorder to expose the 


### PR DESCRIPTION
## Purpose
> Currently in the master branch the build status is not shown as follows:
![Screenshot from 2020-06-24 07-00-24](https://user-images.githubusercontent.com/33062368/85486593-882e5780-b5e8-11ea-8ca0-0da03f39142f.png)

## Goals
> With this fix the badge will be taken through [shields.io](https://shields.io/) and will be shown as follows:
![Screenshot from 2020-06-24 07-01-22](https://user-images.githubusercontent.com/33062368/85486608-8fedfc00-b5e8-11ea-9021-52930b9a42c3.png)

## Release note
> Updated build status badge icon in README.md file

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK: 1.8.0_161
 OS: Ubuntu
Database: Default H2
Browser: Firefox 77.0.1 (64-bit)