### PR TITLE
Remove unnecessary dependency to avoid startup issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,10 @@
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Purpose
Latest api validation is already being packed with latest hibernator. Hence need to remove api validation being packed from other dependency. If the dependency is not removed then during the runtime old dependency is being taken place and throw no such method errors.

