### PR TITLE
Update the spring-web version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <cxf-bundle.version>3.4.5</cxf-bundle.version>
         <olingo-odata2.version>1.1.0</olingo-odata2.version>
         <jackson.version>1.9.13</jackson.version>
-        <spring-web.version>5.1.1.RELEASE</spring-web.version>
+        <spring-web.version>5.3.9</spring-web.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <javax.validation.api.version>2.0.1.Final</javax.validation.api.version>


### PR DESCRIPTION
## Purpose
> Update the spring-jlc, spring-core and spring-beans jars in 'api' webapp to the 5.3.9 spring version.
This is the corresponding public PR of the u2 spring web upgrade https://github.com/wso2-support/identity-rest-dispatcher/pull/8

Related Issue: https://github.com/wso2/product-is/issues/12595