### PR TITLE
Update APIErrorExceptionMapper to generate response for user onboard api error

### DIFF
--- a/components/org.wso2.carbon.identity.api.dispatcher.core/pom.xml
+++ b/components/org.wso2.carbon.identity.api.dispatcher.core/pom.xml
@@ -87,5 +87,9 @@
             <groupId>org.wso2.carbon.identity.user.api</groupId>
             <artifactId>org.wso2.carbon.identity.api.user.common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.user.onboard.common</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/components/org.wso2.carbon.identity.api.dispatcher.core/src/main/java/org/wso2/carbon/identity/api/dispatcher/core/APIErrorExceptionMapper.java
+++ b/components/org.wso2.carbon.identity.api.dispatcher.core/src/main/java/org/wso2/carbon/identity/api/dispatcher/core/APIErrorExceptionMapper.java
@@ -61,6 +61,14 @@ public class APIErrorExceptionMapper implements ExceptionMapper<WebApplicationEx
 
             return buildResponse(response, status);
 
+        } else if (e instanceof org.wso2.carbon.identity.api.user.onboard.common.error.APIError) {
+            Object response = ((org.wso2.carbon.identity.api.user.onboard.common.error.APIError) e).getResponseEntity();
+            Response.Status status =
+                    getHttpsStatusCode(((org.wso2.carbon.identity.api.user.onboard.common.error.APIError)
+                    e).getCode(), ((org.wso2.carbon.identity.api.user.onboard.common.error.APIError) e).getStatus());
+
+            return buildResponse(response, status);
+
         }
         return e.getResponse();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
                 <artifactId>org.wso2.carbon.identity.api.user.common</artifactId>
                 <version>${identity.user.api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.user.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.user.onboard.common</artifactId>
+                <version>${identity.user.api.version}</version>
+            </dependency>
 
 
             <!-- Server REST API Dependencies. -->
@@ -220,7 +225,7 @@
         <commons-lang3.version>3.4</commons-lang3.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
-        <identity.user.api.version>1.2.3</identity.user.api.version>
+        <identity.user.api.version>1.3.34</identity.user.api.version>
         <identity.server.api.version>1.1.10</identity.server.api.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <maven.findbugsplugin.version>3.0.4</maven.findbugsplugin.version>


### PR DESCRIPTION
## Purpose
The APIErrorExceptionMapper needs to map exceptions to responses when the api exception is being thrown by the user onboard api.

This PR updates the `toResponse` method to perform the mapping if the exception is an instance of org.wso2.carbon.identity.api.user.onboard.common.error.APIError

## Related Issue

- https://github.com/wso2/product-is/issues/19456